### PR TITLE
Remove concept/associated from fields

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -170,7 +170,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'concept/associated,concept/nomenclature',
+                    source: 'concept/nomenclature',
                   },
                 },
               },
@@ -238,7 +238,7 @@ export default (configContext) => {
                 view: {
                   type: AutocompleteInput,
                   props: {
-                    source: 'concept/associated,concept/material',
+                    source: 'concept/material',
                   },
                 },
               },


### PR DESCRIPTION
These changes are for the controlled fields which were migrating authorities so that they now only use a single authority.

* Remove concept/associated from materialGroup, so it is only controlled by concept/material
* Remove concept/associated from objectName, so it is only controlled by concept/nomenclature